### PR TITLE
Removes models.SubfieldBase.

### DIFF
--- a/jsonfield2/fields.py
+++ b/jsonfield2/fields.py
@@ -81,6 +81,9 @@ class JSONField(models.Field):
             return 'longtext'
         return 'text'
 
+    def from_db_field(self, value):
+        return self.to_python(value)
+
     def to_python(self, value):
         if isinstance(value, six.string_types):
             if value == "":

--- a/jsonfield2/fields.py
+++ b/jsonfield2/fields.py
@@ -24,7 +24,7 @@ DB_TYPE_CACHE_KEY = (
 )
 
 
-class JSONField(six.with_metaclass(models.SubfieldBase, models.Field)):
+class JSONField(models.Field):
     """
     A field that will ensure the data entered into it is valid JSON.
     """
@@ -32,8 +32,6 @@ class JSONField(six.with_metaclass(models.SubfieldBase, models.Field)):
         'invalid': _("'%s' is not a valid JSON string.")
     }
     description = "JSON object"
-
-    __metaclass__ = models.SubfieldBase
 
     def __init__(self, *args, **kwargs):
         if not kwargs.get('null', False):


### PR DESCRIPTION
Removes the use of models.SubfieldBase because of the upcoming deprecation.

> RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.
